### PR TITLE
Prevent double firing via update to `hyperbee-range-watcher`

### DIFF
--- a/event-watcher.js
+++ b/event-watcher.js
@@ -5,26 +5,15 @@ export class EventWatcher extends EventEmitter {
   constructor (bee, range, latestDiff) {
     super()
 
-    this._lastEventEmittedPerLog = new Map()
-
     this.watcher = new RangeWatcher(bee, range, latestDiff, async (node) => {
-      const { key, value } = node
-      const [inputCoreKey, inputCoreSeqStr] = key.split('!').slice(-2)
-      const inputCoreSeq = parseInt(inputCoreSeqStr, 16)
-      const hasCoreKey = this._lastEventEmittedPerLog.has(inputCoreKey)
-      let prevSeq
-      let isNewer
-      if (hasCoreKey) {
-        prevSeq = this._lastEventEmittedPerLog.get(inputCoreKey)
-        isNewer = prevSeq < inputCoreSeq
-      }
-      if (!hasCoreKey || isNewer) {
-        const eventObj = value
-        const eventDetails = { data: eventObj.data, timestamp: eventObj.timestamp }
-        this._lastEventEmittedPerLog.set(inputCoreKey, inputCoreSeq)
-        this.emit(eventObj.event, eventDetails)
-        this.emit('*', eventObj)
-      }
+      const { type, key, value } = node
+      // Ignore Events somehow removed
+      if (type === 'del') return
+
+      const eventObj = value
+      const eventDetails = { data: eventObj.data, timestamp: eventObj.timestamp }
+      this.emit(eventObj.event, eventDetails)
+      this.emit('*', eventObj)
     })
   }
 }

--- a/event-watcher.js
+++ b/event-watcher.js
@@ -6,7 +6,7 @@ export class EventWatcher extends EventEmitter {
     super()
 
     this.watcher = new RangeWatcher(bee, range, latestDiff, async (node) => {
-      const { type, key, value } = node
+      const { type, value } = node
       // Ignore Events somehow removed
       if (type === 'del') return
 

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ export class EventBus {
 
     // Default starting point
     if (!otherVersion) {
-      otherVersion = this.autobase.view.version || 0
+      otherVersion = this.autobase.view.snapshot()
     }
 
     const watcher = new EventWatcher(this.autobase.view, searchOptions,
@@ -60,7 +60,7 @@ export class EventBus {
     return this.autobase.ready()
   }
 
-  static async eventIndexesApply (batch, bee) {
+  static async eventIndexesApply (batch, bee, base) {
     const b = bee.batch({ update: false })
     const keys = [null, null, null]
 

--- a/index.js
+++ b/index.js
@@ -11,21 +11,19 @@ export const KEY_PREFIX = 'key'
 
 export class EventBus {
   constructor (store, bootstraps = null, opts = {}) {
-    this._hyperbeeOpts = opts
-
     // Set default apply if not provided
-    this._apply = 'apply' in opts ? opts.apply : this.constructor.eventIndexesApply.bind(this)
+    const apply = 'apply' in opts ? opts.apply : this.constructor.eventIndexesApply.bind(this)
 
     this.autobase = new Autobase(store, bootstraps, {
       ...opts,
       open: (viewStore) => {
-        const core = viewStore.get('eventbus-index', opts.valueEncoding)
+        const core = viewStore.get('eventbus-index')
         return new Hyperbee(core, {
-          ...this._hyperbeeOpts,
+          ...opts,
           extension: false
         })
       },
-      apply: this._apply
+      apply
     })
 
     this._watchers = new Map()

--- a/index.js
+++ b/index.js
@@ -33,6 +33,18 @@ export class EventBus {
     return this.autobase.view
   }
 
+  get writable () {
+    return this.autobase.writable
+  }
+
+  get local () {
+    return this.autobase.local
+  }
+
+  get key () {
+    return this.autobase.key
+  }
+
   async setupEventStream (event = '*', otherVersion) {
     if (this._watchers.has(event)) return this._watchers.get(event)
 

--- a/index.js
+++ b/index.js
@@ -120,6 +120,10 @@ export class EventBus {
     return this.autobase.append(eventObj)
   }
 
+  async update (...args) {
+    return this.autobase.update(...args)
+  }
+
   async append (...args) {
     return this.autobase.append(...args)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@lejeunerenard/hyperbee-range-watcher-autobase": "github:lejeunerenard/hyperbee-range-watcher-autobase#1.1.0",
-        "autobase": "^6.0.0-rc0",
+        "@lejeunerenard/hyperbee-range-watcher-autobase": "github:lejeunerenard/hyperbee-range-watcher-autobase#hyperbee-diff-stream",
+        "autobase": "^6.0.0-rc9",
         "autobase-test-helpers": "^2.0.4",
         "hyperbee": "^2.15.0",
         "lexicographic-integer": "^1.1.0"
@@ -114,11 +114,12 @@
       }
     },
     "node_modules/@lejeunerenard/hyperbee-range-watcher-autobase": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#44b9ebc14520429d30c995a5665a346711074e31",
+      "version": "1.1.1",
+      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#637ec35965224f8e2a6b919cb71dbe256bb92912",
       "license": "MIT",
       "dependencies": {
-        "hyperbee": "^2.12.0"
+        "hyperbee": "^2.12.0",
+        "hyperbee-diff-stream": "^1.0.2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -272,9 +273,9 @@
       }
     },
     "node_modules/autobase": {
-      "version": "6.0.0-rc6",
-      "resolved": "https://registry.npmjs.org/autobase/-/autobase-6.0.0-rc6.tgz",
-      "integrity": "sha512-Ab30s6nHd133GNraTzUB8E4UPVSb1gIUmJDxtw1xOnsEY3xkMaespDsyNMvklBs1O1foWpqTDku5kED0MH+EyQ==",
+      "version": "6.0.0-rc9",
+      "resolved": "https://registry.npmjs.org/autobase/-/autobase-6.0.0-rc9.tgz",
+      "integrity": "sha512-m72izKLX0MGxxKWVQI5VGNJvkxetLDfbeQBSDnTHoGUonxCuANGQsYEdIY9yH/tqzyH0v6DcaE1fz9dxe2kZIQ==",
       "dependencies": {
         "b4a": "^1.6.1",
         "bare-events": "^2.2.0",
@@ -1331,6 +1332,16 @@
         "ready-resource": "^1.0.0",
         "safety-catch": "^1.0.2",
         "streamx": "^2.12.4"
+      }
+    },
+    "node_modules/hyperbee-diff-stream": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hyperbee-diff-stream/-/hyperbee-diff-stream-1.0.2.tgz",
+      "integrity": "sha512-fTU6v1Jy132AyTIDRVRUfLnhEd0tKmcEsGzQQlurJqWtXj6Ywj475On1QpiX4eZqBMr5Le35qBurIAfBMpzl+g==",
+      "dependencies": {
+        "b4a": "^1.6.1",
+        "codecs": "^3.0.0",
+        "sorted-union-stream": "^3.2.3"
       }
     },
     "node_modules/hypercore": {
@@ -2421,6 +2432,14 @@
         "xsalsa20": "^1.0.0"
       }
     },
+    "node_modules/sorted-union-stream": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-3.2.3.tgz",
+      "integrity": "sha512-8wbehFBja6u/eVlrn87J9ybABl+BUcpG/Om/uu9yYQcHOzhPi779wkRX61OpgAy1Y9/smkGtlOW/m7oyfAhv+g==",
+      "dependencies": {
+        "streamx": "^2.6.0"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.15.6",
       "license": "MIT",
@@ -2817,10 +2836,11 @@
       }
     },
     "@lejeunerenard/hyperbee-range-watcher-autobase": {
-      "version": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#44b9ebc14520429d30c995a5665a346711074e31",
-      "from": "@lejeunerenard/hyperbee-range-watcher-autobase@github:lejeunerenard/hyperbee-range-watcher-autobase#1.1.0",
+      "version": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#637ec35965224f8e2a6b919cb71dbe256bb92912",
+      "from": "@lejeunerenard/hyperbee-range-watcher-autobase@lejeunerenard/hyperbee-range-watcher-autobase#hyperbee-diff-stream",
       "requires": {
-        "hyperbee": "^2.12.0"
+        "hyperbee": "^2.12.0",
+        "hyperbee-diff-stream": "^1.0.2"
       }
     },
     "@nodelib/fs.scandir": {
@@ -2913,9 +2933,9 @@
       }
     },
     "autobase": {
-      "version": "6.0.0-rc6",
-      "resolved": "https://registry.npmjs.org/autobase/-/autobase-6.0.0-rc6.tgz",
-      "integrity": "sha512-Ab30s6nHd133GNraTzUB8E4UPVSb1gIUmJDxtw1xOnsEY3xkMaespDsyNMvklBs1O1foWpqTDku5kED0MH+EyQ==",
+      "version": "6.0.0-rc9",
+      "resolved": "https://registry.npmjs.org/autobase/-/autobase-6.0.0-rc9.tgz",
+      "integrity": "sha512-m72izKLX0MGxxKWVQI5VGNJvkxetLDfbeQBSDnTHoGUonxCuANGQsYEdIY9yH/tqzyH0v6DcaE1fz9dxe2kZIQ==",
       "requires": {
         "b4a": "^1.6.1",
         "bare-events": "^2.2.0",
@@ -3626,6 +3646,16 @@
         "streamx": "^2.12.4"
       }
     },
+    "hyperbee-diff-stream": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hyperbee-diff-stream/-/hyperbee-diff-stream-1.0.2.tgz",
+      "integrity": "sha512-fTU6v1Jy132AyTIDRVRUfLnhEd0tKmcEsGzQQlurJqWtXj6Ywj475On1QpiX4eZqBMr5Le35qBurIAfBMpzl+g==",
+      "requires": {
+        "b4a": "^1.6.1",
+        "codecs": "^3.0.0",
+        "sorted-union-stream": "^3.2.3"
+      }
+    },
     "hypercore": {
       "version": "10.33.0",
       "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.33.0.tgz",
@@ -4325,6 +4355,14 @@
         "sodium-javascript": "~0.8.0",
         "sodium-native": "^4.0.0",
         "xsalsa20": "^1.0.0"
+      }
+    },
+    "sorted-union-stream": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-3.2.3.tgz",
+      "integrity": "sha512-8wbehFBja6u/eVlrn87J9ybABl+BUcpG/Om/uu9yYQcHOzhPi779wkRX61OpgAy1Y9/smkGtlOW/m7oyfAhv+g==",
+      "requires": {
+        "streamx": "^2.6.0"
       }
     },
     "streamx": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,11 +115,11 @@
     },
     "node_modules/@lejeunerenard/hyperbee-range-watcher-autobase": {
       "version": "1.1.1",
-      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#637ec35965224f8e2a6b919cb71dbe256bb92912",
+      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#e4715d5edca9377cf4db807c5c0407412c6fb81c",
       "license": "MIT",
       "dependencies": {
         "hyperbee": "^2.12.0",
-        "hyperbee-diff-stream": "^1.0.2"
+        "hyperbee-diff-stream": "github:lejeunerenard/hyperbee-diff-stream#fix-optional-values"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -273,9 +273,9 @@
       }
     },
     "node_modules/autobase": {
-      "version": "6.0.0-rc9",
-      "resolved": "https://registry.npmjs.org/autobase/-/autobase-6.0.0-rc9.tgz",
-      "integrity": "sha512-m72izKLX0MGxxKWVQI5VGNJvkxetLDfbeQBSDnTHoGUonxCuANGQsYEdIY9yH/tqzyH0v6DcaE1fz9dxe2kZIQ==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/autobase/-/autobase-6.0.15.tgz",
+      "integrity": "sha512-yo+IKemk5WODblylDtb5kINnfw/VUtjCAurQL5sw4a6weE8wEM8r8QV2ojCZ85chC9+5g9Eby7TDyNl2NvIdNA==",
       "dependencies": {
         "b4a": "^1.6.1",
         "bare-events": "^2.2.0",
@@ -287,6 +287,7 @@
         "nanoassert": "^2.0.0",
         "ready-resource": "^1.0.0",
         "safety-catch": "^1.0.2",
+        "signal-promise": "^1.0.3",
         "sub-encoder": "^2.1.1",
         "tiny-buffer-map": "^1.1.1"
       }
@@ -1335,9 +1336,9 @@
       }
     },
     "node_modules/hyperbee-diff-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hyperbee-diff-stream/-/hyperbee-diff-stream-1.0.2.tgz",
-      "integrity": "sha512-fTU6v1Jy132AyTIDRVRUfLnhEd0tKmcEsGzQQlurJqWtXj6Ywj475On1QpiX4eZqBMr5Le35qBurIAfBMpzl+g==",
+      "version": "1.0.3",
+      "resolved": "git+ssh://git@github.com/lejeunerenard/hyperbee-diff-stream.git#ccf4425957ec55eda8a91c04524a6d6b51fc66df",
+      "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.1",
         "codecs": "^3.0.0",
@@ -2353,6 +2354,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-promise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/signal-promise/-/signal-promise-1.0.3.tgz",
+      "integrity": "sha512-WBgv0UnIq2C+Aeh0/n+IRpP6967eIx9WpynTUoiW3isPpfe1zu2LJzyfXdo9Tgef8yR/sGjcMvoUXD7EYdiz+g=="
+    },
     "node_modules/signed-varint": {
       "version": "2.0.1",
       "license": "MIT",
@@ -2836,11 +2842,11 @@
       }
     },
     "@lejeunerenard/hyperbee-range-watcher-autobase": {
-      "version": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#637ec35965224f8e2a6b919cb71dbe256bb92912",
+      "version": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#e4715d5edca9377cf4db807c5c0407412c6fb81c",
       "from": "@lejeunerenard/hyperbee-range-watcher-autobase@lejeunerenard/hyperbee-range-watcher-autobase#hyperbee-diff-stream",
       "requires": {
         "hyperbee": "^2.12.0",
-        "hyperbee-diff-stream": "^1.0.2"
+        "hyperbee-diff-stream": "github:lejeunerenard/hyperbee-diff-stream#fix-optional-values"
       }
     },
     "@nodelib/fs.scandir": {
@@ -2933,9 +2939,9 @@
       }
     },
     "autobase": {
-      "version": "6.0.0-rc9",
-      "resolved": "https://registry.npmjs.org/autobase/-/autobase-6.0.0-rc9.tgz",
-      "integrity": "sha512-m72izKLX0MGxxKWVQI5VGNJvkxetLDfbeQBSDnTHoGUonxCuANGQsYEdIY9yH/tqzyH0v6DcaE1fz9dxe2kZIQ==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/autobase/-/autobase-6.0.15.tgz",
+      "integrity": "sha512-yo+IKemk5WODblylDtb5kINnfw/VUtjCAurQL5sw4a6weE8wEM8r8QV2ojCZ85chC9+5g9Eby7TDyNl2NvIdNA==",
       "requires": {
         "b4a": "^1.6.1",
         "bare-events": "^2.2.0",
@@ -2947,6 +2953,7 @@
         "nanoassert": "^2.0.0",
         "ready-resource": "^1.0.0",
         "safety-catch": "^1.0.2",
+        "signal-promise": "^1.0.3",
         "sub-encoder": "^2.1.1",
         "tiny-buffer-map": "^1.1.1"
       }
@@ -3647,9 +3654,8 @@
       }
     },
     "hyperbee-diff-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hyperbee-diff-stream/-/hyperbee-diff-stream-1.0.2.tgz",
-      "integrity": "sha512-fTU6v1Jy132AyTIDRVRUfLnhEd0tKmcEsGzQQlurJqWtXj6Ywj475On1QpiX4eZqBMr5Le35qBurIAfBMpzl+g==",
+      "version": "git+ssh://git@github.com/lejeunerenard/hyperbee-diff-stream.git#ccf4425957ec55eda8a91c04524a6d6b51fc66df",
+      "from": "hyperbee-diff-stream@github:lejeunerenard/hyperbee-diff-stream#fix-optional-values",
       "requires": {
         "b4a": "^1.6.1",
         "codecs": "^3.0.0",
@@ -4289,6 +4295,11 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "signal-promise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/signal-promise/-/signal-promise-1.0.3.tgz",
+      "integrity": "sha512-WBgv0UnIq2C+Aeh0/n+IRpP6967eIx9WpynTUoiW3isPpfe1zu2LJzyfXdo9Tgef8yR/sGjcMvoUXD7EYdiz+g=="
     },
     "signed-varint": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@lejeunerenard/hyperbee-range-watcher-autobase": "github:lejeunerenard/hyperbee-range-watcher-autobase#hyperbee-diff-stream",
         "autobase": "^6.0.0-rc9",
         "autobase-test-helpers": "^2.0.4",
+        "bare-fs": "^2.3.0",
         "hyperbee": "^2.15.0",
         "lexicographic-integer": "^1.1.0"
       },
@@ -24,6 +25,11 @@
         "eslint-plugin-promise": "^6.1.1",
         "random-access-memory": "^6.2.1",
         "tape": "^5.6.1"
+      },
+      "optionalDependencies": {
+        "bare-assert": "^1.0.1",
+        "bare-events": "^2.2.2",
+        "bare-fs": "^2.3.0"
       }
     },
     "../autobase-next": {
@@ -319,10 +325,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.0.1.tgz",
+      "integrity": "sha512-30PfMTqaR+IhP6SJgRnV7hPKs/1Al1EHIUnp8bRMVM571Jn5/oZP7V0r1Zc13ePqjktssuAzibI6fORlVpZ0XQ==",
+      "optional": true
+    },
     "node_modules/bare-events": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.0.tgz",
-      "integrity": "sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
+      "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ=="
+    },
+    "node_modules/bare-fs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.0.tgz",
+      "integrity": "sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-path": "^2.0.0",
+        "bare-stream": "^1.0.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.3.0.tgz",
+      "integrity": "sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==",
+      "optional": true
+    },
+    "node_modules/bare-path": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.2.tgz",
+      "integrity": "sha512-o7KSt4prEphWUHa3QUwCxUI00R86VdjiuxmJK0iNVDHYPGo+HsDaVCnqCmPbf/MiW1ok8F4p3m8RTHlWk8K2ig==",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^2.1.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-1.0.0.tgz",
+      "integrity": "sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.16.1"
+      }
     },
     "node_modules/big-sparse-array": {
       "version": "1.0.3",
@@ -2447,11 +2494,15 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.6",
-      "license": "MIT",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
+      "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
       "dependencies": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -2843,7 +2894,7 @@
     },
     "@lejeunerenard/hyperbee-range-watcher-autobase": {
       "version": "git+ssh://git@github.com/lejeunerenard/hyperbee-range-watcher-autobase.git#e4715d5edca9377cf4db807c5c0407412c6fb81c",
-      "from": "@lejeunerenard/hyperbee-range-watcher-autobase@lejeunerenard/hyperbee-range-watcher-autobase#hyperbee-diff-stream",
+      "from": "@lejeunerenard/hyperbee-range-watcher-autobase@github:lejeunerenard/hyperbee-range-watcher-autobase#hyperbee-diff-stream",
       "requires": {
         "hyperbee": "^2.12.0",
         "hyperbee-diff-stream": "github:lejeunerenard/hyperbee-diff-stream#fix-optional-values"
@@ -2975,10 +3026,51 @@
       "version": "1.0.2",
       "dev": true
     },
+    "bare-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.0.1.tgz",
+      "integrity": "sha512-30PfMTqaR+IhP6SJgRnV7hPKs/1Al1EHIUnp8bRMVM571Jn5/oZP7V0r1Zc13ePqjktssuAzibI6fORlVpZ0XQ==",
+      "optional": true
+    },
     "bare-events": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.0.tgz",
-      "integrity": "sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
+      "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ=="
+    },
+    "bare-fs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.0.tgz",
+      "integrity": "sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==",
+      "optional": true,
+      "requires": {
+        "bare-events": "^2.0.0",
+        "bare-path": "^2.0.0",
+        "bare-stream": "^1.0.0"
+      }
+    },
+    "bare-os": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.3.0.tgz",
+      "integrity": "sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==",
+      "optional": true
+    },
+    "bare-path": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.2.tgz",
+      "integrity": "sha512-o7KSt4prEphWUHa3QUwCxUI00R86VdjiuxmJK0iNVDHYPGo+HsDaVCnqCmPbf/MiW1ok8F4p3m8RTHlWk8K2ig==",
+      "optional": true,
+      "requires": {
+        "bare-os": "^2.1.0"
+      }
+    },
+    "bare-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-1.0.0.tgz",
+      "integrity": "sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==",
+      "optional": true,
+      "requires": {
+        "streamx": "^2.16.1"
+      }
     },
     "big-sparse-array": {
       "version": "1.0.3"
@@ -4377,8 +4469,11 @@
       }
     },
     "streamx": {
-      "version": "2.15.6",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
+      "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
       "requires": {
+        "bare-events": "^2.2.0",
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "tape": "^5.6.1"
   },
   "dependencies": {
-    "@lejeunerenard/hyperbee-range-watcher-autobase": "github:lejeunerenard/hyperbee-range-watcher-autobase#1.1.0",
-    "autobase": "^6.0.0-rc0",
+    "@lejeunerenard/hyperbee-range-watcher-autobase": "github:lejeunerenard/hyperbee-range-watcher-autobase#hyperbee-diff-stream",
+    "autobase": "^6.0.0-rc9",
     "autobase-test-helpers": "^2.0.4",
     "hyperbee": "^2.15.0",
     "lexicographic-integer": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,20 @@
   "keywords": [],
   "author": "Sean Zellmer <sean@lejeunerenard.com> (http://lejeunerenard.com/)",
   "license": "MIT",
+  "imports": {
+    "assert": {
+      "bare": "bare-assert",
+      "default": "assert"
+    },
+    "events": {
+      "bare": "bare-events",
+      "default": "events"
+    },
+    "fs": {
+      "bare": "bare-fs",
+      "default": "fs"
+    }
+  },
   "devDependencies": {
     "corestore": "^6.15.13",
     "eslint": "^8.27.0",
@@ -27,5 +41,10 @@
     "autobase-test-helpers": "^2.0.4",
     "hyperbee": "^2.15.0",
     "lexicographic-integer": "^1.1.0"
+  },
+  "optionalDependencies": {
+    "bare-assert": "^1.0.1",
+    "bare-events": "^2.2.2",
+    "bare-fs": "^2.3.0"
   }
 }

--- a/tests/event-bus.js
+++ b/tests/event-bus.js
@@ -58,10 +58,7 @@ test('EventBus', (t) => {
       const corestore = new Corestore(RAM)
 
       // Normal use
-      const bus = new EventBus(corestore, null, {
-        valueEncoding: 'json',
-        localInput: corestore.get({ name: 'emitLocalInput' })
-      })
+      const bus = new EventBus(corestore, null, { valueEncoding: 'json' })
       try {
         await bus.emit('beep', 'foo', 2, 'baz')
         t.pass('doesnt throw w/ normal use')
@@ -76,10 +73,7 @@ test('EventBus', (t) => {
     t.test('object arguments', async (t) => {
       const corestore = new Corestore(RAM)
 
-      const bus = new EventBus(corestore, null, {
-        valueEncoding: 'json',
-        localInput: corestore.get({ name: 'emitLocalInput' })
-      })
+      const bus = new EventBus(corestore, null, { valueEncoding: 'json' })
 
       await asyncThrows(async () =>
         await bus.emit({}),

--- a/tests/event-bus.js
+++ b/tests/event-bus.js
@@ -190,7 +190,7 @@ test('EventBus', (t) => {
       await bus1.ready()
 
       // Bus 2
-      const bus2 = new EventBus(corestore2, [bus1.autobase.local.key], {
+      const bus2 = new EventBus(corestore2, [bus1.local.key], {
         keyEncoding: 'utf-8',
         valueEncoding: 'json',
         apply
@@ -203,7 +203,7 @@ test('EventBus', (t) => {
       stream1.pipe(stream2).pipe(stream1)
 
       // Add other bus
-      await addWriter(bus1.autobase, bus2.autobase.local.key)
+      await addWriter(bus1, bus2.local.key)
 
       let timesBus1EventWasCalled = 0
       let timesAEventWasCalled = 0
@@ -259,7 +259,7 @@ test('EventBus', (t) => {
       // // TODO Figure out how to not trigger apply/update from setupEventStream
       // // running. The solution might be a more intelligent way to kick it off
       // // than the autobase append event.
-      // bus.autobase.view.feed.on('append', () => {
+      // bus.view.feed.on('append', () => {
       //   console.log('bus hyperbee append fired')
       // })
 
@@ -358,7 +358,7 @@ test('EventBus', (t) => {
     })
     await peerA.ready()
 
-    const peerB = new EventBus(corestore, [peerA.autobase.local.key], {
+    const peerB = new EventBus(corestore, [peerA.local.key], {
       keyEncoding: 'utf-8',
       valueEncoding: 'json',
       apply
@@ -370,7 +370,7 @@ test('EventBus', (t) => {
     stream1.pipe(stream2).pipe(stream1)
 
     // Add other bus
-    await addWriter(peerA.autobase, peerB.autobase.local.key)
+    await addWriter(peerA, peerB.local.key)
 
     const expectedCalls = 83
     let pingCalls = 0
@@ -458,7 +458,7 @@ test('EventBus', (t) => {
     await bus.emit('biz', 2)
     await bus.emit('click', 3)
 
-    const total = await bus.autobase.view.get('total')
+    const total = await bus.view.get('total')
     t.equals(total.value, 6)
   })
 

--- a/tests/event-bus.js
+++ b/tests/event-bus.js
@@ -38,9 +38,6 @@ test('EventBus', (t) => {
     const corestore = new Corestore(RAM.reusable())
     const bus = new EventBus(corestore)
 
-    // Public properties
-    t.ok(bus.autobase, 'has autobase property')
-
     try {
       await bus.close()
       t.pass('doesnt throw w/ normal use')
@@ -167,8 +164,7 @@ test('EventBus', (t) => {
         }),
         new Promise((resolve, reject) => {
           setTimeout(() => {
-            bus.emit('after', 1337)
-            resolve()
+            resolve(bus.emit('after', 1337))
           }, 50)
         })
       ]

--- a/tests/event-bus.js
+++ b/tests/event-bus.js
@@ -222,36 +222,36 @@ test('EventBus', (t) => {
       let timesBus1EventWasCalled = 0
       let timesAEventWasCalled = 0
 
-      bus1.on('bus1Event', ({ data }) => {
+      bus1.on('message1:bus1', ({ data }) => {
         timesBus1EventWasCalled++
         if (timesBus1EventWasCalled === 1) {
-          t.pass('bus1Event callback on bus1 was fired')
+          t.pass('message1:bus1 callback on bus1 was fired')
         } else {
-          t.fail('bus1Event callback on bus1 was called more than once')
+          t.fail('message1:bus1 callback on bus1 was called more than once')
         }
       })
-      bus1.on('aardvarkEvent', ({ data }) => {
+      bus1.on('amessage2:bus1', ({ data }) => {
         timesAEventWasCalled++
         if (timesAEventWasCalled === 1) {
-          t.pass('aardvarkEvent callback on bus1 was fired')
+          t.pass('amessage2:bus1 callback on bus1 was fired')
         } else {
-          t.fail('aardvarkEvent callback on bus1 was called more than once')
+          t.fail('amessage2:bus1 callback on bus1 was called more than once')
         }
       })
-      bus2.on('bus2Event', () => {
-        t.pass('bus2Event callback on bus2 was fired')
+      bus2.on('message1:bus2', () => {
+        t.pass('message1:bus2 callback on bus2 was fired')
       })
 
       await eventFlush()
 
       const tasks = [
-        bus1.emit('filler', 'frombus1'),
-        bus1.emit('bus1Event', 'a'), // Must be after filler
-        bus1.emit('aardvarkEvent'), // Must be after bus1 so it comes before when hyperbee is queried via event name
-        bus2.emit('bus2Event'),
-        bus2.emit('filler', 'frombus2'),
-        bus2.emit('filler', 'frombus2'),
-        bus2.emit('filler', 'frombus2')
+        bus1.emit('filler:bus1', 'frombus1'),
+        bus1.emit('message1:bus1', 'a'), // Must be after filler
+        bus1.emit('amessage2:bus1'), // Must be after bus1 so it comes before when hyperbee is queried via event name
+        bus2.emit('message1:bus2'),
+        bus2.emit('filler:bus2', 'frombus2'),
+        bus2.emit('filler:bus2', 'frombus2'),
+        bus2.emit('filler:bus2', 'frombus2')
       ]
       await Promise.all(tasks)
     })

--- a/tests/event-bus.js
+++ b/tests/event-bus.js
@@ -23,7 +23,7 @@ async function asyncThrows (fn, err, t, message = 'throws') {
 
 test('EventBus', (t) => {
   t.test('construction', (t) => {
-    const corestore = new Corestore(RAM)
+    const corestore = new Corestore(RAM.reusable())
     const bus = new EventBus(corestore)
 
     // Public properties
@@ -35,7 +35,7 @@ test('EventBus', (t) => {
   })
 
   t.test('close', async (t) => {
-    const corestore = new Corestore(RAM)
+    const corestore = new Corestore(RAM.reusable())
     const bus = new EventBus(corestore)
 
     // Public properties
@@ -54,7 +54,7 @@ test('EventBus', (t) => {
 
   t.test('emit', async (t) => {
     t.test('basic usage', async (t) => {
-      const corestore = new Corestore(RAM)
+      const corestore = new Corestore(RAM.reusable())
 
       // Normal use
       const bus = new EventBus(corestore, null, { valueEncoding: 'json' })
@@ -70,7 +70,7 @@ test('EventBus', (t) => {
     })
 
     t.test('object arguments', async (t) => {
-      const corestore = new Corestore(RAM)
+      const corestore = new Corestore(RAM.reusable())
 
       const bus = new EventBus(corestore, null, { valueEncoding: 'json' })
 
@@ -103,7 +103,7 @@ test('EventBus', (t) => {
     t.test('w/ eagerUpdate false', async (t) => {
       t.plan(2)
 
-      const corestoreError = new Corestore(RAM)
+      const corestoreError = new Corestore(RAM.reusable())
 
       const errorEmitBus = new EventBus(corestoreError, [])
       t.throws(() => errorEmitBus.on(), /event must be a string/,
@@ -111,7 +111,7 @@ test('EventBus', (t) => {
       await errorEmitBus.close()
 
       // Normal use
-      const corestore = new Corestore(RAM)
+      const corestore = new Corestore(RAM.reusable())
       const bus = new EventBus(corestore, null, {
         keyEncoding: 'utf-8',
         valueEncoding: 'json'
@@ -139,7 +139,7 @@ test('EventBus', (t) => {
     t.test('w/ eagerUpdate true', async (t) => {
       t.plan(2)
 
-      const corestore = new Corestore(RAM)
+      const corestore = new Corestore(RAM.reusable())
 
       // Normal use
       const bus = new EventBus(corestore, null, {
@@ -179,8 +179,8 @@ test('EventBus', (t) => {
     t.test('doesnt refire when linearized core resequences', async (t) => {
       t.plan(3)
 
-      const corestore = new Corestore(RAM)
-      const corestore2 = new Corestore(RAM)
+      const corestore = new Corestore(RAM.reusable())
+      const corestore2 = new Corestore(RAM.reusable())
 
       const [apply, addWriter] = applyWriterManagement(false)
 
@@ -248,7 +248,7 @@ test('EventBus', (t) => {
 
     t.test('fires event when emit is fired during indexing', async (t) => {
       t.plan(1)
-      const corestore = new Corestore(RAM)
+      const corestore = new Corestore(RAM.reusable())
 
       // Bus 1
       const bus = new EventBus(corestore, null, {
@@ -285,7 +285,7 @@ test('EventBus', (t) => {
 
     t.test('`*` support', async (t) => {
       t.plan(4)
-      const store = new Corestore(RAM)
+      const store = new Corestore(RAM.reusable())
 
       const bus = new EventBus(store, null, {
         keyEncoding: 'utf-8',
@@ -350,8 +350,8 @@ test('EventBus', (t) => {
   t.test('replication', async (t) => {
     t.plan(3)
 
-    const corestore = new Corestore(RAM)
-    const corestore2 = new Corestore(RAM)
+    const corestore = new Corestore(RAM.reusable())
+    const corestore2 = new Corestore(RAM.reusable())
 
     const [apply, addWriter] = applyWriterManagement(false)
 
@@ -424,7 +424,7 @@ test('EventBus', (t) => {
 
   t.test('apply function can be extended', async (t) => {
     t.plan(2)
-    const corestore = new Corestore(RAM)
+    const corestore = new Corestore(RAM.reusable())
 
     const bus = new EventBus(corestore, null, {
       keyEncoding: 'utf-8',


### PR DESCRIPTION
`hyperbee-range-watcher` now supports firing via `hyperbee-diff-stream` which prevents double fires by checking the keys being updated and doing a diff stream on the previous snapshot vs the current snapshot.